### PR TITLE
Inject shared OpenAIService into agents

### DIFF
--- a/agentic-project-assistant/no_framework/agentic_workflow.py
+++ b/agentic-project-assistant/no_framework/agentic_workflow.py
@@ -2,6 +2,7 @@
 
 # Import the following agents: ActionPlanningAgent, KnowledgeAugmentedPromptAgent, EvaluationAgent, RoutingAgent from the workflow_agents.base_agents module
 from agents.base_agents import ActionPlanningAgent, KnowledgeAugmentedPromptAgent, EvaluationAgent, RoutingAgent
+from agents.openai_service import OpenAIService
 
 import os
 from dotenv import load_dotenv
@@ -9,6 +10,9 @@ from dotenv import load_dotenv
 # Load the OpenAI key into a variable called openai_api_key
 load_dotenv()  # Load environment variables from .env file
 openai_api_key = os.getenv("OPENAI_API_KEY")
+
+# Create a single OpenAIService instance to share across agents
+openai_service = OpenAIService(api_key=openai_api_key)
 
 # load the product spec
 # Load the product spec document Product-Spec-Email-Router.txt into a variable called product_spec
@@ -33,9 +37,9 @@ knowledge_action_planning = (
     "A development Plan for a product contains all these components"
 )
 # Instantiate an action_planning_agent using the 'knowledge_action_planning'
-action_planning_agent = ActionPlanningAgent(    
+action_planning_agent = ActionPlanningAgent(
     knowledge=knowledge_action_planning,
-    openai_api_key=openai_api_key
+    openai_service=openai_service
 )
 
 # Product Manager - Knowledge Augmented Prompt Agent
@@ -47,10 +51,10 @@ knowledge_product_manager = (
     f"Here is the product spec: {product_spec}"
 )
 # Instantiate a product_manager_knowledge_agent using 'persona_product_manager' and the completed 'knowledge_product_manager'
-product_manager_knowledge_agent = KnowledgeAugmentedPromptAgent(    
+product_manager_knowledge_agent = KnowledgeAugmentedPromptAgent(
     persona=persona_product_manager,
     knowledge=knowledge_product_manager,
-    openai_api_key=openai_api_key
+    openai_service=openai_service
 )
 
 # Product Manager - Evaluation Agent
@@ -63,21 +67,21 @@ evaluation_criteria_product_manager = (
     "Each user story should be clear, concise, and focused on a specific user need. "
     "The user stories should be relevant to the product spec provided."
 )
-product_manager_evaluation_agent = EvaluationAgent(    
+product_manager_evaluation_agent = EvaluationAgent(
     persona=persona_product_manager_eval,
     evaluation_criteria=evaluation_criteria_product_manager,
     worker_agent=product_manager_knowledge_agent,
-    openai_api_key=openai_api_key
-) 
+    openai_service=openai_service
+)
 
 # Program Manager - Knowledge Augmented Prompt Agent
 persona_program_manager = "You are a Program Manager, you are responsible for defining the features for a product."
 knowledge_program_manager = "Features of a product are defined by organizing similar user stories into cohesive groups."
 # Instantiate a program_manager_knowledge_agent using 'persona_program_manager' and 'knowledge_program_manager'
-program_manager_knowledge_agent = KnowledgeAugmentedPromptAgent(    
+program_manager_knowledge_agent = KnowledgeAugmentedPromptAgent(
     persona=persona_program_manager,
     knowledge=knowledge_program_manager,
-    openai_api_key=openai_api_key
+    openai_service=openai_service
 )
 
 # Program Manager - Evaluation Agent
@@ -90,7 +94,7 @@ persona_program_manager_eval = "You are an evaluation agent that checks the answ
 #                      "Key Functionality: The specific capabilities or actions the feature provides\n" \
 #                      "User Benefit: How this feature creates value for the user"
 # For the 'agent_to_evaluate' parameter, refer to the provided solution code's pattern.
-program_manager_evaluation_agent = EvaluationAgent(    
+program_manager_evaluation_agent = EvaluationAgent(
     persona=persona_program_manager_eval,
     evaluation_criteria=(
         "The answer should be product features that follow the following structure: "
@@ -100,17 +104,17 @@ program_manager_evaluation_agent = EvaluationAgent(
         "User Benefit: How this feature creates value for the user"
     ),
     worker_agent=program_manager_knowledge_agent,
-    openai_api_key=openai_api_key
+    openai_service=openai_service
 )
 
 # Development Engineer - Knowledge Augmented Prompt Agent
 persona_dev_engineer = "You are a Development Engineer, you are responsible for defining the development tasks for a product."
 knowledge_dev_engineer = "Development tasks are defined by identifying what needs to be built to implement each user story."
 # Instantiate a development_engineer_knowledge_agent using 'persona_dev_engineer' and 'knowledge_dev_engineer'
-development_engineer_knowledge_agent = KnowledgeAugmentedPromptAgent(    
+development_engineer_knowledge_agent = KnowledgeAugmentedPromptAgent(
     persona=persona_dev_engineer,
     knowledge=knowledge_dev_engineer,
-    openai_api_key=openai_api_key
+    openai_service=openai_service
 )
 
 # Development Engineer - Evaluation Agent
@@ -125,7 +129,7 @@ persona_dev_engineer_eval = "You are an evaluation agent that checks the answers
 #                      "Estimated Effort: Time or complexity estimation\n" \
 #                      "Dependencies: Any tasks that must be completed first"
 # For the 'agent_to_evaluate' parameter, refer to the provided solution code's pattern.
-development_engineer_evaluation_agent = EvaluationAgent(    
+development_engineer_evaluation_agent = EvaluationAgent(
     persona=persona_dev_engineer_eval,
     evaluation_criteria=(
         "The answer should be tasks following this exact structure: "
@@ -138,13 +142,13 @@ development_engineer_evaluation_agent = EvaluationAgent(
         "Dependencies: Any tasks that must be completed first"
     ),
     worker_agent=development_engineer_knowledge_agent,
-    openai_api_key=openai_api_key
+    openai_service=openai_service
 )
 
 
 # Routing Agent
 # Instantiate a routing_agent. You will need to define a list of agent dictionaries (routes) for Product Manager, Program Manager, and Development Engineer. Each dictionary should contain 'name', 'description', and 'func' (linking to a support function). Assign this list to the routing_agent's 'agents' attribute.
-routing_agent = RoutingAgent(    
+routing_agent = RoutingAgent(
     agents=[
         {
             "name": "Product Manager ",
@@ -162,7 +166,7 @@ routing_agent = RoutingAgent(
             "func": "placeholder"
         }
     ],
-    openai_api_key=openai_api_key
+    openai_service=openai_service
 )
 
 # Job function persona support functions

--- a/agentic-project-assistant/no_framework/agents/openai_service.py
+++ b/agentic-project-assistant/no_framework/agents/openai_service.py
@@ -1,0 +1,16 @@
+from openai import OpenAI
+
+
+class OpenAIService:
+    """Simple wrapper around the OpenAI client used by the agents."""
+
+    def __init__(self, api_key: str, base_url: str = "https://openai.vocareum.com/v1"):
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def chat(self, **kwargs):
+        """Call the chat completion endpoint."""
+        return self.client.chat.completions.create(**kwargs)
+
+    def embed(self, **kwargs):
+        """Call the embeddings endpoint."""
+        return self.client.embeddings.create(**kwargs)

--- a/agentic-project-assistant/no_framework/tests/action_planning_agent.py
+++ b/agentic-project-assistant/no_framework/tests/action_planning_agent.py
@@ -3,11 +3,13 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.base_agents import ActionPlanningAgent
+from agents.openai_service import OpenAIService
 from dotenv import load_dotenv
 
 # Load environment variables and define the openai_api_key variable with your OpenAI API key
 load_dotenv()
 openai_api_key = os.getenv("OPENAI_API_KEY")
+openai_service = OpenAIService(api_key=openai_api_key)
 
 knowledge = """
 # Fried Egg
@@ -39,7 +41,7 @@ knowledge = """
 
 # Instantiate the ActionPlanningAgent, passing the openai_api_key and the knowledge variable
 action_planning_agent = ActionPlanningAgent(
-    openai_api_key=openai_api_key,
+    openai_service=openai_service,
     knowledge=knowledge
 )
 

--- a/agentic-project-assistant/no_framework/tests/augmented_prompt_agent.py
+++ b/agentic-project-assistant/no_framework/tests/augmented_prompt_agent.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 # Import the AugmentedPromptAgent class
 from agents.base_agents import AugmentedPromptAgent
+from agents.openai_service import OpenAIService
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -11,12 +12,13 @@ load_dotenv()
 
 # Retrieve OpenAI API key from environment variables
 openai_api_key = os.getenv("OPENAI_API_KEY")
+openai_service = OpenAIService(api_key=openai_api_key)
 
 prompt = "What is the capital of France?"
 persona = "You are a college professor; your answers always start with: 'Dear students,'"
 
 # Instantiate an object of AugmentedPromptAgent with the required parameters
-agent = AugmentedPromptAgent(openai_api_key=openai_api_key, persona=persona)
+agent = AugmentedPromptAgent(openai_service=openai_service, persona=persona)
 
 # Send the 'prompt' to the agent and store the response in a variable named 'augmented_agent_response'
 augmented_agent_response = agent.respond(prompt)

--- a/agentic-project-assistant/no_framework/tests/direct_prompt_agent.py
+++ b/agentic-project-assistant/no_framework/tests/direct_prompt_agent.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 
 from agents.base_agents import DirectPromptAgent
+from agents.openai_service import OpenAIService
 import os
 from dotenv import load_dotenv
 
@@ -13,11 +14,12 @@ load_dotenv()
 
 # Load the OpenAI API key from the environment variables
 openai_api_key = os.getenv("OPENAI_API_KEY")
+openai_service = OpenAIService(api_key=openai_api_key)
 
 prompt = "What is the Capital of France?"
 
 # Instantiate the DirectPromptAgent as direct_agent
-direct_agent = DirectPromptAgent(openai_api_key=openai_api_key)
+direct_agent = DirectPromptAgent(openai_service=openai_service)
 
 # Use direct_agent to send the prompt defined above and store the response
 direct_agent_response = direct_agent.respond(prompt)

--- a/agentic-project-assistant/no_framework/tests/evaluation_agent.py
+++ b/agentic-project-assistant/no_framework/tests/evaluation_agent.py
@@ -3,12 +3,14 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.base_agents import EvaluationAgent, KnowledgeAugmentedPromptAgent
+from agents.openai_service import OpenAIService
 from dotenv import load_dotenv
 
 # Load environment variables
 load_dotenv()
 
 openai_api_key = os.getenv("OPENAI_API_KEY")
+openai_service = OpenAIService(api_key=openai_api_key)
 prompt = "What is the capital of France?"
 
 # Parameters for the Knowledge Agent
@@ -17,7 +19,7 @@ knowledge = "The capitol of France is London, not Paris"
 
 # Instantiate the KnowledgeAugmentedPromptAgent here
 knowledge_agent = KnowledgeAugmentedPromptAgent(
-    openai_api_key=openai_api_key, persona=persona, knowledge=knowledge)
+    openai_service=openai_service, persona=persona, knowledge=knowledge)
 
 # Parameters for the Evaluation Agent
 persona = "You are an evaluation agent that checks the answers of other worker agents"
@@ -25,7 +27,7 @@ evaluation_criteria = "The answer should be solely the name of a city, not a sen
 
 # Instantiate the EvaluationAgent with a maximum of 10 interactions here
 evaluation_agent = EvaluationAgent(
-    openai_api_key=openai_api_key,
+    openai_service=openai_service,
     persona=persona,
     evaluation_criteria=evaluation_criteria,
     worker_agent=knowledge_agent,

--- a/agentic-project-assistant/no_framework/tests/knowledge_augmented_prompt_agent.py
+++ b/agentic-project-assistant/no_framework/tests/knowledge_augmented_prompt_agent.py
@@ -3,6 +3,7 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.base_agents import KnowledgeAugmentedPromptAgent
+from agents.openai_service import OpenAIService
 
 from dotenv import load_dotenv
 
@@ -11,6 +12,7 @@ load_dotenv()
 
 # Define the parameters for the agent
 openai_api_key = os.getenv("OPENAI_API_KEY")
+openai_service = OpenAIService(api_key=openai_api_key)
 
 prompt = "What is the capital of France?"
 knowledge = "The capital of France is London, not Paris"
@@ -21,7 +23,7 @@ persona = "You are a college professor, your answer always starts with: Dear stu
 # - Knowledge: "The capital of France is London, not Paris"
 
 knowledge_agent = KnowledgeAugmentedPromptAgent(
-    openai_api_key=openai_api_key, persona=persona, knowledge=knowledge)
+    openai_service=openai_service, persona=persona, knowledge=knowledge)
 
 # Write a print statement that demonstrates the agent using the provided knowledge rather than its own inherent knowledge.
 knowledge_agent_response = knowledge_agent.respond(prompt)

--- a/agentic-project-assistant/no_framework/tests/rag_knowledge_prompt_agent.py
+++ b/agentic-project-assistant/no_framework/tests/rag_knowledge_prompt_agent.py
@@ -3,6 +3,7 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.base_agents import RAGKnowledgePromptAgent
+from agents.openai_service import OpenAIService
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -10,6 +11,7 @@ load_dotenv()
 
 # Define the parameters for the agent
 openai_api_key = os.getenv("OPENAI_API_KEY")
+openai_service = OpenAIService(api_key=openai_api_key)
 
 chunk_size = 1000  # Define the size of each chunk
 
@@ -17,7 +19,7 @@ persona = "You are a college professor, your answer always starts with: Dear stu
 
 # Instantiate RAGKnowledgePromptAgent
 RAG_knowledge_prompt_agent = RAGKnowledgePromptAgent(
-    openai_api_key=openai_api_key, persona=persona, chunk_size=chunk_size)
+    openai_service=openai_service, persona=persona, chunk_size=chunk_size)
 
 knowledge_text = """
 In the historic city of Boston, Clara, a marine biologist and science communicator, began each morning analyzing sonar data to track whale migration patterns along the Atlantic coast.

--- a/agentic-project-assistant/no_framework/tests/routing_agent.py
+++ b/agentic-project-assistant/no_framework/tests/routing_agent.py
@@ -4,11 +4,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from dotenv import load_dotenv
 from agents.base_agents import KnowledgeAugmentedPromptAgent, RoutingAgent
+from agents.openai_service import OpenAIService
 
 # Load environment variables from .env file
 load_dotenv()
 
 openai_api_key = os.getenv("OPENAI_API_KEY")
+openai_service = OpenAIService(api_key=openai_api_key)
 
 persona = "You are a college professor"
 
@@ -16,22 +18,22 @@ knowledge = "You know everything about Texas"
 # Define the Texas Knowledge Augmented Prompt Agent
 
 texas_agent = KnowledgeAugmentedPromptAgent(
-    openai_api_key=openai_api_key, persona=persona, knowledge=knowledge)
+    openai_service=openai_service, persona=persona, knowledge=knowledge)
 
 knowledge = "You know everything about Europe"
 
 # Define the Europe Knowledge Augmented Prompt Agent
 europe_agent = KnowledgeAugmentedPromptAgent(
-    openai_api_key=openai_api_key, persona=persona, knowledge=knowledge)
+    openai_service=openai_service, persona=persona, knowledge=knowledge)
 
 persona = "You are a college math professor"
 knowledge = "You know everything about math, you take prompts with numbers, extract math formulas, and show the answer without explanation"
 
 # Define the Math Knowledge Augmented Prompt Agent
 math_agent = KnowledgeAugmentedPromptAgent(
-    openai_api_key=openai_api_key, persona=persona, knowledge=knowledge)
+    openai_service=openai_service, persona=persona, knowledge=knowledge)
 
-routing_agent = RoutingAgent(openai_api_key=openai_api_key,
+routing_agent = RoutingAgent(openai_service=openai_service,
     agents = [
         {
             "name": "texas agent",


### PR DESCRIPTION
## Summary
- add `OpenAIService` wrapper for chat and embedding calls
- refactor all agents to accept a shared `OpenAIService`
- update workflow to create one `OpenAIService` and pass to agents
- modify tests to use the new service

## Testing
- `python run_all_agents_tests.py` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877754358848328addb856053645092