### PR TITLE
Add shared config helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Agentic Workflow Comparison
+
+This repository contains various sample agents demonstrating how to interact with the OpenAI API.
+
+## Configuration
+
+Create a `.env` file in the project root with at least the following variables:
+
+```
+OPENAI_API_KEY=your-key
+# Optional alternative base URL
+OPENAI_BASE_URL=https://openai.vocareum.com/v1
+```
+
+Use the helper functions from `config.py` to access these values:
+
+```python
+from config import load_openai_api_key, load_openai_base_url
+
+api_key = load_openai_api_key()
+base_url = load_openai_base_url()
+```
+
+All modules and tests in this repo import these functions instead of calling `load_dotenv()` directly.

--- a/agentic-project-assistant/no_framework/agentic_workflow.py
+++ b/agentic-project-assistant/no_framework/agentic_workflow.py
@@ -9,16 +9,16 @@ from agents.base_agents import (
 )
 from agents.openai_service import OpenAIService
 from utils.logging_config import logger
-
+from config import load_openai_api_key, load_openai_base_url
 import os
-from dotenv import load_dotenv
 
-# Load the OpenAI key into a variable called openai_api_key
-load_dotenv()  # Load environment variables from .env file
-openai_api_key = os.getenv("OPENAI_API_KEY")
+
+# Load OpenAI credentials using the shared config helper
+openai_api_key = load_openai_api_key()
+openai_base_url = load_openai_base_url()
 
 # Create a single OpenAIService instance to share across agents
-openai_service = OpenAIService(api_key=openai_api_key)
+openai_service = OpenAIService(api_key=openai_api_key, base_url=openai_base_url)
 
 # load the product spec
 # Load the product spec document Product-Spec-Email-Router.txt into a variable called product_spec

--- a/agentic-project-assistant/no_framework/config.py
+++ b/agentic-project-assistant/no_framework/config.py
@@ -1,0 +1,14 @@
+import os
+from dotenv import load_dotenv
+
+
+def load_openai_api_key() -> str:
+    """Return the OpenAI API key from environment variables or a .env file."""
+    load_dotenv()
+    return os.getenv("OPENAI_API_KEY")
+
+
+def load_openai_base_url() -> str:
+    """Return the OpenAI base URL, defaulting to Vocareum's endpoint."""
+    load_dotenv()
+    return os.getenv("OPENAI_BASE_URL", "https://openai.vocareum.com/v1")

--- a/agentic-project-assistant/no_framework/tests/action_planning_agent.py
+++ b/agentic-project-assistant/no_framework/tests/action_planning_agent.py
@@ -4,12 +4,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from agents.base_agents import ActionPlanningAgent
 from agents.openai_service import OpenAIService
-from dotenv import load_dotenv
+from config import load_openai_api_key, load_openai_base_url
 
-# Load environment variables and define the openai_api_key variable with your OpenAI API key
-load_dotenv()
-openai_api_key = os.getenv("OPENAI_API_KEY")
-openai_service = OpenAIService(api_key=openai_api_key)
+# Load OpenAI credentials using the shared config helper
+openai_api_key = load_openai_api_key()
+openai_base_url = load_openai_base_url()
+openai_service = OpenAIService(api_key=openai_api_key, base_url=openai_base_url)
 
 knowledge = """
 # Fried Egg
@@ -49,3 +49,4 @@ action_planning_agent = ActionPlanningAgent(
 prompt = "One morning I wanted to have scrambled eggs"
 response = action_planning_agent.extract_steps_from_prompt(prompt)
 print(f"Action Planning Response: {response}")
+

--- a/agentic-project-assistant/no_framework/tests/augmented_prompt_agent.py
+++ b/agentic-project-assistant/no_framework/tests/augmented_prompt_agent.py
@@ -5,14 +5,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 # Import the AugmentedPromptAgent class
 from agents.base_agents import AugmentedPromptAgent
 from agents.openai_service import OpenAIService
-from dotenv import load_dotenv
+from config import load_openai_api_key, load_openai_base_url
 
-# Load environment variables from .env file
-load_dotenv()
-
-# Retrieve OpenAI API key from environment variables
-openai_api_key = os.getenv("OPENAI_API_KEY")
-openai_service = OpenAIService(api_key=openai_api_key)
+# Load OpenAI credentials using the shared config helper
+openai_api_key = load_openai_api_key()
+openai_base_url = load_openai_base_url()
+openai_service = OpenAIService(api_key=openai_api_key, base_url=openai_base_url)
 
 prompt = "What is the capital of France?"
 persona = "You are a college professor; your answers always start with: 'Dear students,'"
@@ -34,3 +32,4 @@ print(augmented_agent_response)
 print("The agent's response is expected to be a formal answer, such as 'Dear students, the capital of France is Paris.'")
 print("This is because the agent's persona is set to that of a college professor, which influences")
 print("the style and tone of the response.")  # This line is added to complete the comment
+

--- a/agentic-project-assistant/no_framework/tests/direct_prompt_agent.py
+++ b/agentic-project-assistant/no_framework/tests/direct_prompt_agent.py
@@ -6,15 +6,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from agents.base_agents import DirectPromptAgent
 from agents.openai_service import OpenAIService
-import os
-from dotenv import load_dotenv
+from config import load_openai_api_key, load_openai_base_url
 
-# Load environment variables from .env file
-load_dotenv()
-
-# Load the OpenAI API key from the environment variables
-openai_api_key = os.getenv("OPENAI_API_KEY")
-openai_service = OpenAIService(api_key=openai_api_key)
+# Load OpenAI credentials using the shared config helper
+openai_api_key = load_openai_api_key()
+openai_base_url = load_openai_base_url()
+openai_service = OpenAIService(api_key=openai_api_key, base_url=openai_base_url)
 
 prompt = "What is the Capital of France?"
 

--- a/agentic-project-assistant/no_framework/tests/evaluation_agent.py
+++ b/agentic-project-assistant/no_framework/tests/evaluation_agent.py
@@ -5,14 +5,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from agents.base_agents import EvaluationAgent, KnowledgeAugmentedPromptAgent
 from agents.openai_service import OpenAIService
-from dotenv import load_dotenv
+from config import load_openai_api_key, load_openai_base_url
 import logging
 
-# Load environment variables
-load_dotenv()
-
-openai_api_key = os.getenv("OPENAI_API_KEY")
-openai_service = OpenAIService(api_key=openai_api_key)
+# Load OpenAI credentials using the shared config helper
+openai_api_key = load_openai_api_key()
+openai_base_url = load_openai_base_url()
+openai_service = OpenAIService(api_key=openai_api_key, base_url=openai_base_url)
 prompt = "What is the capital of France?"
 
 # Parameters for the Knowledge Agent
@@ -45,3 +44,4 @@ print(f"Final Response: {response['final_response']}")
 print(f"Evaluation: {response['evaluation']}")
 print(f"Number of Iterations: {response['iterations']}")
 print("✅ Evaluation completed successfully.")
+

--- a/agentic-project-assistant/no_framework/tests/knowledge_augmented_prompt_agent.py
+++ b/agentic-project-assistant/no_framework/tests/knowledge_augmented_prompt_agent.py
@@ -4,15 +4,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from agents.base_agents import KnowledgeAugmentedPromptAgent
 from agents.openai_service import OpenAIService
+from config import load_openai_api_key, load_openai_base_url
 
-from dotenv import load_dotenv
-
-# Load environment variables from the .env file
-load_dotenv()
-
-# Define the parameters for the agent
-openai_api_key = os.getenv("OPENAI_API_KEY")
-openai_service = OpenAIService(api_key=openai_api_key)
+# Load OpenAI credentials using the shared config helper
+openai_api_key = load_openai_api_key()
+openai_base_url = load_openai_base_url()
+openai_service = OpenAIService(api_key=openai_api_key, base_url=openai_base_url)
 
 prompt = "What is the capital of France?"
 knowledge = "The capital of France is London, not Paris"
@@ -28,3 +25,4 @@ knowledge_agent = KnowledgeAugmentedPromptAgent(
 # Write a print statement that demonstrates the agent using the provided knowledge rather than its own inherent knowledge.
 knowledge_agent_response = knowledge_agent.respond(prompt)
 print(knowledge_agent_response)
+

--- a/agentic-project-assistant/no_framework/tests/rag_knowledge_prompt_agent.py
+++ b/agentic-project-assistant/no_framework/tests/rag_knowledge_prompt_agent.py
@@ -4,14 +4,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from agents.base_agents import RAGKnowledgePromptAgent
 from agents.openai_service import OpenAIService
-from dotenv import load_dotenv
+from config import load_openai_api_key, load_openai_base_url
 
-# Load environment variables from .env file
-load_dotenv()
-
-# Define the parameters for the agent
-openai_api_key = os.getenv("OPENAI_API_KEY")
-openai_service = OpenAIService(api_key=openai_api_key)
+# Load OpenAI credentials using the shared config helper
+openai_api_key = load_openai_api_key()
+openai_base_url = load_openai_base_url()
+openai_service = OpenAIService(api_key=openai_api_key, base_url=openai_base_url)
 
 chunk_size = 1000  # Define the size of each chunk
 

--- a/agentic-project-assistant/no_framework/tests/routing_agent.py
+++ b/agentic-project-assistant/no_framework/tests/routing_agent.py
@@ -2,15 +2,14 @@ import sys
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from dotenv import load_dotenv
 from agents.base_agents import KnowledgeAugmentedPromptAgent, RoutingAgent
 from agents.openai_service import OpenAIService
+from config import load_openai_api_key, load_openai_base_url
 
-# Load environment variables from .env file
-load_dotenv()
-
-openai_api_key = os.getenv("OPENAI_API_KEY")
-openai_service = OpenAIService(api_key=openai_api_key)
+# Load OpenAI credentials using the shared config helper
+openai_api_key = load_openai_api_key()
+openai_base_url = load_openai_base_url()
+openai_service = OpenAIService(api_key=openai_api_key, base_url=openai_base_url)
 
 persona = "You are a college professor"
 


### PR DESCRIPTION
## Summary
- centralize OpenAI API config in `no_framework/config.py`
- update workflow and tests to use the new helper
- document configuration in new README

## Testing
- `python run_all_agents_tests.py` *(fails: OpenAI API key not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68777c28c1488328b0eb9a93ced37bbf