### PR TITLE
Refactor RAG agent utilities

### DIFF
--- a/agentic-project-assistant/no_framework/tests/rag_knowledge_prompt_agent.py
+++ b/agentic-project-assistant/no_framework/tests/rag_knowledge_prompt_agent.py
@@ -3,6 +3,8 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.base_agents import RAGKnowledgePromptAgent
+from utils.text_chunker import TextChunker
+from utils.embedding_store import EmbeddingStore
 from agents.openai_service import OpenAIService
 from config import load_openai_api_key, load_openai_base_url
 
@@ -16,8 +18,14 @@ chunk_size = 1000  # Define the size of each chunk
 persona = "You are a college professor, your answer always starts with: Dear students,"
 
 # Instantiate RAGKnowledgePromptAgent
+chunker = TextChunker(chunk_size=chunk_size)
+store = EmbeddingStore("test_rag")
 RAG_knowledge_prompt_agent = RAGKnowledgePromptAgent(
-    openai_service=openai_service, persona=persona, chunk_size=chunk_size)
+    openai_service=openai_service,
+    persona=persona,
+    chunker=chunker,
+    store=store,
+)
 
 knowledge_text = """
 In the historic city of Boston, Clara, a marine biologist and science communicator, began each morning analyzing sonar data to track whale migration patterns along the Atlantic coast.

--- a/agentic-project-assistant/no_framework/utils/embedding_store.py
+++ b/agentic-project-assistant/no_framework/utils/embedding_store.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import numpy as np
+from typing import List, Dict
+
+
+class EmbeddingStore:
+    """Persist and load text chunks and their embeddings using CSV files."""
+
+    def __init__(self, name: str):
+        self.chunks_file = f"chunks-{name}.csv"
+        self.embeddings_file = f"embeddings-{name}.csv"
+
+    def save_chunks(self, chunks: List[Dict]) -> None:
+        df = pd.DataFrame([{"text": c["text"], "chunk_size": c["chunk_size"]} for c in chunks])
+        df.to_csv(self.chunks_file, encoding="utf-8", index=False)
+
+    def load_chunks(self) -> pd.DataFrame:
+        return pd.read_csv(self.chunks_file, encoding="utf-8")
+
+    def save_embeddings(self, df: pd.DataFrame) -> None:
+        df.to_csv(self.embeddings_file, encoding="utf-8", index=False)
+
+    def load_embeddings(self) -> pd.DataFrame:
+        df = pd.read_csv(self.embeddings_file, encoding="utf-8")
+        df["embeddings"] = df["embeddings"].apply(lambda x: np.array(eval(x)))
+        return df

--- a/agentic-project-assistant/no_framework/utils/text_chunker.py
+++ b/agentic-project-assistant/no_framework/utils/text_chunker.py
@@ -1,0 +1,44 @@
+import re
+from typing import List, Dict
+
+
+class TextChunker:
+    """Utility class for splitting text into overlapping chunks."""
+
+    def __init__(self, chunk_size: int = 2000, chunk_overlap: int = 100):
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+
+    def chunk(self, text: str) -> List[Dict]:
+        """Return a list of chunk dictionaries without writing to disk."""
+        text = re.sub(r"\s+", " ", text).strip()
+        separator = "\n"
+        step = self.chunk_size - self.chunk_overlap
+
+        chunks = []
+        start = 0
+        chunk_id = 0
+        text_len = len(text)
+
+        while start < text_len:
+            end = min(start + self.chunk_size, text_len)
+            window_text = text[start:end]
+            last_sep = window_text.rfind(separator)
+            if last_sep != -1 and (start + last_sep + len(separator)) < text_len:
+                end = start + last_sep + len(separator)
+
+            chunk_text = text[start:end]
+            chunks.append(
+                {
+                    "chunk_id": chunk_id,
+                    "text": chunk_text,
+                    "chunk_size": len(chunk_text),
+                    "start_char": start,
+                    "end_char": end,
+                }
+            )
+
+            start += step
+            chunk_id += 1
+
+        return chunks


### PR DESCRIPTION
## Summary
- add `TextChunker` utility to produce text chunks without writing to disk
- add `EmbeddingStore` to persist chunk embeddings
- refactor `RAGKnowledgePromptAgent` to rely on the new utilities
- update RAG test script to use the new components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877867f73088328806d8c339a3ecb4e