### PR TITLE
Add LangChain implementation of agentic workflow

### DIFF
--- a/agentic-project-assistant/langchain/agents.py
+++ b/agentic-project-assistant/langchain/agents.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, List
+
+from langchain.chat_models import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate
+from langchain.chains import LLMChain
+from langchain.embeddings import OpenAIEmbeddings
+import numpy as np
+
+
+@dataclass
+class ActionPlanningChain:
+    """LangChain implementation of ``ActionPlanningAgent``."""
+
+    llm: ChatOpenAI
+    knowledge: str
+    chain: LLMChain = field(init=False)
+
+    def __post_init__(self) -> None:
+        system_msg = (
+            "You are an action planning agent tasked with creating a clear, ordered sequence of instructions for completing a product development task.\n"
+            "Your output must:\n"
+            "\u2013 Be a numbered list (e.g., 1., 2., 3.)\n"
+            "\u2013 Follow this strict order:\n   1. Product Manager \u2192 2. Program Manager \u2192 3. Development Engineer\n"
+            "\u2013 Each numbered step must be a single sentence, beginning with: 'You as the [role] should...'\n"
+            "Only use these roles:\n"
+            "\u2022 Product Manager: Defines user stories from the product spec.\n"
+            "\u2022 Program Manager: Extracts features from user stories.\n"
+            "\u2022 Development Engineer: Translates features into development tasks.\n"
+            "Do not create role headers. Do not split instructions across lines.\n"
+            "Each item in the list must be a full, standalone directive.\n"
+            "Use this knowledge: {knowledge}"
+        )
+        prompt = ChatPromptTemplate.from_messages([
+            SystemMessagePromptTemplate.from_template(system_msg),
+            HumanMessagePromptTemplate.from_template("{input}"),
+        ])
+        self.chain = LLMChain(llm=self.llm, prompt=prompt.partial(knowledge=self.knowledge))
+
+    def run(self, prompt: str) -> List[str]:
+        response = self.chain.run({"input": prompt})
+        steps = [s.strip() for s in response.split("\n") if s.strip() and not s.startswith("Step")]
+        return steps
+
+
+@dataclass
+class KnowledgeAgent:
+    """Knowledge augmented agent implemented with LangChain."""
+
+    llm: ChatOpenAI
+    persona: str
+    knowledge: str
+    chain: LLMChain = field(init=False)
+
+    def __post_init__(self) -> None:
+        prompt = ChatPromptTemplate.from_messages([
+            SystemMessagePromptTemplate.from_template(
+                "Forget all previous context. You are {persona}, a knowledge-based assistant.\n"
+                "Use only the following knowledge to answer, do not use your own knowledge:\n"
+                "KNOWLEDGE: {knowledge} KNOWLEDGE END\n"
+                "Answer the prompt based on this knowledge, not your own."
+            ),
+            HumanMessagePromptTemplate.from_template("{input}"),
+        ])
+        self.chain = LLMChain(
+            llm=self.llm,
+            prompt=prompt.partial(persona=self.persona, knowledge=self.knowledge),
+        )
+
+    def run(self, prompt: str) -> str:
+        return self.chain.run({"input": prompt})
+
+
+@dataclass
+class EvaluationAgent:
+    """Evaluation agent that checks responses from another agent."""
+
+    llm: ChatOpenAI
+    persona: str
+    evaluation_criteria: str
+    worker: KnowledgeAgent
+    max_interactions: int = 10
+    eval_chain: LLMChain = field(init=False)
+    instruction_chain: LLMChain = field(init=False)
+
+    def __post_init__(self) -> None:
+        eval_prompt = ChatPromptTemplate.from_messages([
+            SystemMessagePromptTemplate.from_template(
+                "You are {persona}, an impartial evaluation agent.\n"
+                "You must decide if the following answer meets the evaluation criterion:\n"
+                "CRITERION: {criteria}\n"
+                "Your response must be strictly formatted:\n"
+                "First line: 'Yes' or 'No'\n"
+                "Second line: A one-sentence explanation why.\n"
+                "Do not suggest improvements. Do not change or reinterpret the criterion."
+            ),
+            HumanMessagePromptTemplate.from_template("Answer: {answer}"),
+        ])
+        self.eval_chain = LLMChain(
+            llm=self.llm,
+            prompt=eval_prompt.partial(persona=self.persona, criteria=self.evaluation_criteria),
+        )
+
+        instruction_prompt = ChatPromptTemplate.from_messages([
+            SystemMessagePromptTemplate.from_template(
+                "You are {persona}, a helpful assistant that generates concise correction instructions."
+            ),
+            HumanMessagePromptTemplate.from_template(
+                "Provide instructions to fix an answer based on these reasons why it is incorrect: {evaluation}"
+            ),
+        ])
+        self.instruction_chain = LLMChain(
+            llm=self.llm,
+            prompt=instruction_prompt.partial(persona=self.persona),
+        )
+
+    def run(self, initial_prompt: str) -> dict[str, Any]:
+        prompt_to_evaluate = initial_prompt
+        worker_response = ""
+        evaluation = ""
+        for i in range(self.max_interactions):
+            worker_response = self.worker.run(prompt_to_evaluate)
+            evaluation = self.eval_chain.run({"answer": worker_response}).strip()
+            if evaluation.lower().startswith("yes"):
+                break
+            instructions = self.instruction_chain.run({"evaluation": evaluation}).strip()
+            prompt_to_evaluate = (
+                f"The original prompt was: {initial_prompt}\n"
+                f"The response to that prompt was: {worker_response}\n"
+                f"It has been evaluated as incorrect.\n"
+                f"Make only these corrections, do not alter content validity: {instructions}"
+            )
+        return {
+            "final_response": worker_response,
+            "evaluation": evaluation,
+            "iterations": i + 1,
+        }
+
+
+@dataclass
+class Route:
+    name: str
+    description: str
+    func: Callable[[str], Any]
+    embedding: List[float] | None = None
+
+
+class EmbeddingRouter:
+    """Simple router that selects the best route based on embedding similarity."""
+
+    def __init__(self, routes: List[Route], embeddings: OpenAIEmbeddings) -> None:
+        self.routes = routes
+        self.embeddings = embeddings
+        for route in self.routes:
+            route.embedding = self.embeddings.embed_query(route.description)
+
+    def route(self, prompt: str) -> Any:
+        input_emb = self.embeddings.embed_query(prompt)
+        best = None
+        best_score = -1.0
+        for route in self.routes:
+            emb = route.embedding
+            score = float(np.dot(input_emb, emb) / (np.linalg.norm(input_emb) * np.linalg.norm(emb)))
+            if score > best_score:
+                best_score = score
+                best = route
+        if best is None:
+            return "Sorry, no suitable agent could be selected."
+        return best.func(prompt)

--- a/agentic-project-assistant/langchain/main.py
+++ b/agentic-project-assistant/langchain/main.py
@@ -1,0 +1,198 @@
+import os
+import sys
+
+# Allow importing from the no_framework package
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "no_framework")))
+
+from config import load_openai_api_key, load_openai_base_url
+from utils.logging_config import logger
+
+from langchain.chat_models import ChatOpenAI
+from langchain.embeddings import OpenAIEmbeddings
+
+from .agents import (
+    ActionPlanningChain,
+    KnowledgeAgent,
+    EvaluationAgent,
+    Route,
+    EmbeddingRouter,
+)
+
+
+def main() -> None:
+    openai_api_key = load_openai_api_key()
+    openai_base_url = load_openai_base_url()
+
+    llm = ChatOpenAI(
+        openai_api_key=openai_api_key,
+        openai_api_base=openai_base_url,
+        model="gpt-3.5-turbo",
+        temperature=0,
+    )
+    embeddings = OpenAIEmbeddings(
+        openai_api_key=openai_api_key,
+        openai_api_base=openai_base_url,
+    )
+
+    product_spec_path = os.path.join(
+        os.path.dirname(__file__), "..", "no_framework", "Product-Spec-Email-Router.txt"
+    )
+    if not os.path.exists(product_spec_path):
+        raise FileNotFoundError(f"Product spec file not found at {product_spec_path}")
+
+    with open(product_spec_path, "r", encoding="utf-8") as f:
+        product_spec = f.read()
+
+    # Instantiate Action Planning chain
+    knowledge_action_planning = (
+        "Stories are defined from a product spec by identifying a persona, an action, and a desired outcome for each story. "
+        "Each story represents a specific functionality of the product described in the specification. \n"
+        "Features are defined by grouping related user stories. \n"
+        "Tasks are defined for each story and represent the engineering work required to develop the product. \n"
+        "A development Plan for a product contains all these components"
+    )
+    action_planning_agent = ActionPlanningChain(llm=llm, knowledge=knowledge_action_planning)
+
+    # Product Manager agents
+    persona_product_manager = "You are a Product Manager, you are responsible for defining the user stories for a product."
+    knowledge_product_manager = (
+        "Stories are defined by writing sentences with a persona, an action, and a desired outcome. "
+        "The sentences always start with: As a "
+        "Write several stories for the product spec below, where the personas are the different users of the product. "
+        f"Here is the product spec: {product_spec}"
+    )
+    product_manager_knowledge_agent = KnowledgeAgent(
+        llm=llm,
+        persona=persona_product_manager,
+        knowledge=knowledge_product_manager,
+    )
+
+    persona_product_manager_eval = "You are an evaluation agent that checks the answers of other worker agents."
+    evaluation_criteria_product_manager = (
+        "The answer should be user stories that follow this structure: "
+        "As a [type of user], I want [an action or feature] so that [benefit/value]. "
+        "Each user story should be clear, concise, and focused on a specific user need. "
+        "The user stories should be relevant to the product spec provided."
+    )
+    product_manager_evaluation_agent = EvaluationAgent(
+        llm=llm,
+        persona=persona_product_manager_eval,
+        evaluation_criteria=evaluation_criteria_product_manager,
+        worker=product_manager_knowledge_agent,
+    )
+
+    # Program Manager agents
+    persona_program_manager = "You are a Program Manager, you are responsible for defining the features for a product."
+    knowledge_program_manager = "Features of a product are defined by organizing similar user stories into cohesive groups."
+    program_manager_knowledge_agent = KnowledgeAgent(
+        llm=llm,
+        persona=persona_program_manager,
+        knowledge=knowledge_program_manager,
+    )
+
+    persona_program_manager_eval = "You are an evaluation agent that checks the answers of other worker agents."
+    program_manager_evaluation_agent = EvaluationAgent(
+        llm=llm,
+        persona=persona_program_manager_eval,
+        evaluation_criteria=(
+            "The answer should be product features that follow the following structure: "
+            "Feature Name: A clear, concise title that identifies the capability\n"
+            "Description: A brief explanation of what the feature does and its purpose\n"
+            "Key Functionality: The specific capabilities or actions the feature provides\n"
+            "User Benefit: How this feature creates value for the user"
+        ),
+        worker=program_manager_knowledge_agent,
+    )
+
+    # Development Engineer agents
+    persona_dev_engineer = "You are a Development Engineer, you are responsible for defining the development tasks for a product."
+    knowledge_dev_engineer = "Development tasks are defined by identifying what needs to be built to implement each user story."
+    development_engineer_knowledge_agent = KnowledgeAgent(
+        llm=llm,
+        persona=persona_dev_engineer,
+        knowledge=knowledge_dev_engineer,
+    )
+
+    persona_dev_engineer_eval = "You are an evaluation agent that checks the answers of other worker agents."
+    development_engineer_evaluation_agent = EvaluationAgent(
+        llm=llm,
+        persona=persona_dev_engineer_eval,
+        evaluation_criteria=(
+            "The answer should be tasks following this exact structure: "
+            "Task ID: A unique identifier for tracking purposes\n"
+            "Task Title: Brief description of the specific development work\n"
+            "Related User Story: Reference to the parent user story\n"
+            "Description: Detailed explanation of the technical work required\n"
+            "Acceptance Criteria: Specific requirements that must be met for completion\n"
+            "Estimated Effort: Time or complexity estimation\n"
+            "Dependencies: Any tasks that must be completed first"
+        ),
+        worker=development_engineer_knowledge_agent,
+    )
+
+    # Support functions for router
+    def product_manager_support(query: str):
+        response = product_manager_knowledge_agent.run(query)
+        return product_manager_evaluation_agent.run(response)
+
+    def program_manager_support(query: str):
+        response = program_manager_knowledge_agent.run(query)
+        return program_manager_evaluation_agent.run(response)
+
+    def development_engineer_support(query: str):
+        response = development_engineer_knowledge_agent.run(query)
+        return development_engineer_evaluation_agent.run(response)
+
+    routes = [
+        Route(
+            name="Product Manager",
+            description="Responsible for defining product personas and user stories only.",
+            func=product_manager_support,
+        ),
+        Route(
+            name="Program Manager",
+            description="A Program Manager, who is responsible for defining the features for a product.",
+            func=program_manager_support,
+        ),
+        Route(
+            name="Development Engineer",
+            description="A Development Engineer, who is responsible for defining the development tasks for a product.",
+            func=development_engineer_support,
+        ),
+    ]
+
+    router = EmbeddingRouter(routes=routes, embeddings=embeddings)
+
+    logger.info("\n*** Workflow execution started ***\n")
+    workflow_prompt = "What would the development tasks for this product be?"
+    logger.info("Task to complete in this workflow, workflow prompt = %s", workflow_prompt)
+
+    logger.info("\nDefining workflow steps from the workflow prompt")
+    extracted_steps = action_planning_agent.run(workflow_prompt)
+    completed_steps: list = []
+    context_prompt = ""
+
+    logger.info("Extracted steps from the workflow prompt: %s\n", extracted_steps)
+    logger.info("Executing each step in the workflow...")
+
+    for i, step in enumerate(extracted_steps):
+        full_prompt = (context_prompt + f"\n{step}").strip()
+        logger.info("Executing step %d: %s", i + 1, step)
+        result = router.route(full_prompt)
+        completed_steps.append(result)
+        if isinstance(result, dict) and "final_response" in result:
+            context_prompt += "\n" + result["final_response"]
+        else:
+            context_prompt += "\n" + str(result)
+        logger.info("Result of step '%s': %s", step, result)
+
+    logger.info("Workflow completed successfully.")
+    logger.info("\n*** Workflow Results ***")
+    for i, step in enumerate(completed_steps, start=1):
+        logger.info("Step %d: %s", i, step)
+    logger.info("Final output of the workflow: %s", completed_steps[-1])
+    logger.info("\n*** Workflow execution finished ***\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pandas==2.2.3
 openai==1.78.1
 python-dotenv==1.1.0
+langchain==0.2.1
+tiktoken==0.5.2


### PR DESCRIPTION
## Summary
- migrate manual workflow to LangChain version under `langchain/`
- implement ActionPlanning, Knowledge and Evaluation agents using LLMChain
- add an embedding based router and main driver script
- include LangChain dependencies

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not install langchain due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6877aa1a07dc83289a278dcc867e7e90