### PR TITLE
Add AutoGen-based workflow

### DIFF
--- a/agentic-project-assistant/autogen_based/agents.py
+++ b/agentic-project-assistant/autogen_based/agents.py
@@ -1,0 +1,173 @@
+"""AutoGen-based agent implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List
+
+import autogen
+
+# Basic AutoGen config helper
+
+def _default_llm_config(api_key: str, base_url: str, model: str = "gpt-3.5-turbo") -> dict:
+    """Return a basic llm_config dictionary for AutoGen agents."""
+    return {
+        "config_list": [
+            {"model": model, "api_key": api_key, "base_url": base_url}
+        ],
+        "cache_seed": 42,
+    }
+
+
+@dataclass
+class ActionPlanningAgent:
+    """Agent that extracts ordered action steps from a prompt."""
+
+    llm_config: dict
+    knowledge: str
+
+    def __post_init__(self) -> None:
+        system_message = (
+            "You are an action planning agent tasked with creating a clear, ordered "
+            "sequence of instructions for completing a product development task.\n"
+            "Your output must:\n"
+            "- Be a numbered list (e.g., 1., 2., 3.)\n"
+            "- Follow this strict order: 1. Product Manager -> 2. Program Manager -> 3. Development Engineer\n"
+            "- Each numbered step must be a single sentence beginning with 'You as the [role] should...'\n"
+            "Only use these roles:\n"
+            "• Product Manager: Defines user stories from the product spec.\n"
+            "• Program Manager: Extracts features from user stories.\n"
+            "• Development Engineer: Translates features into development tasks.\n"
+            "Do not create role headers. Do not split instructions across lines.\n"
+            "Each item in the list must be a full, standalone directive.\n"
+            f"Use this knowledge: {self.knowledge}"
+        )
+        self.assistant = autogen.AssistantAgent(
+            name="action_planner",
+            llm_config=self.llm_config,
+            system_message=system_message,
+        )
+        self.user = autogen.UserProxyAgent(
+            name="action_planner_user",
+            human_input_mode="NEVER",
+        )
+
+    def extract_steps_from_prompt(self, prompt: str) -> List[str]:
+        self.user.initiate_chat(self.assistant, message=prompt, summary_method="last_msg")
+        response = self.user.last_message()["content"].strip()
+        steps = [s.strip() for s in response.split("\n") if s.strip() and not s.startswith("Step")]
+        return steps
+
+    def respond(self, prompt: str) -> Any:
+        return self.extract_steps_from_prompt(prompt)
+
+
+@dataclass
+class KnowledgeAgent:
+    """Knowledge augmented agent implemented with AutoGen."""
+
+    llm_config: dict
+    persona: str
+    knowledge: str
+
+    def __post_init__(self) -> None:
+        system_message = (
+            f"Forget all previous context. You are {self.persona}.\n"
+            "Use only the following knowledge to answer, do not use your own knowledge:\n"
+            f"KNOWLEDGE: {self.knowledge} KNOWLEDGE END\n"
+            "Answer the prompt based on this knowledge, not your own."
+        )
+        self.assistant = autogen.AssistantAgent(
+            name=self.persona.replace(" ", "_").lower(),
+            llm_config=self.llm_config,
+            system_message=system_message,
+        )
+        self.user = autogen.UserProxyAgent(
+            name=f"{self.assistant.name}_user",
+            human_input_mode="NEVER",
+        )
+
+    def respond(self, prompt: str) -> str:
+        self.user.initiate_chat(self.assistant, message=prompt, summary_method="last_msg")
+        return self.user.last_message()["content"].strip()
+
+
+@dataclass
+class EvaluationAgent:
+    """Evaluation agent that checks responses from another agent."""
+
+    llm_config: dict
+    persona: str
+    evaluation_criteria: str
+    worker: KnowledgeAgent
+    max_interactions: int = 10
+
+    def __post_init__(self) -> None:
+        eval_system_message = (
+            f"You are {self.persona}, an impartial evaluation agent.\n"
+            f"You must decide if the following answer meets the evaluation criterion:\n"
+            f"CRITERION: {self.evaluation_criteria}\n"
+            "Your response must be strictly formatted:\n"
+            "First line: 'Yes' or 'No'\n"
+            "Second line: A one-sentence explanation why.\n"
+            "Do not suggest improvements. Do not change or reinterpret the criterion."
+        )
+        self.evaluator = autogen.AssistantAgent(
+            name="evaluator",
+            llm_config=self.llm_config,
+            system_message=eval_system_message,
+        )
+        instruction_system_message = (
+            f"You are {self.persona}, a helpful assistant that generates concise correction instructions."
+        )
+        self.instructor = autogen.AssistantAgent(
+            name="instructor",
+            llm_config=self.llm_config,
+            system_message=instruction_system_message,
+        )
+        self.user = autogen.UserProxyAgent(
+            name="evaluation_user",
+            human_input_mode="NEVER",
+        )
+
+    def evaluate_once(self, answer: str) -> str:
+        self.user.initiate_chat(
+            self.evaluator,
+            message=f"Answer: {answer}",
+            summary_method="last_msg",
+        )
+        return self.user.last_message()["content"].strip()
+
+    def get_instructions(self, evaluation: str) -> str:
+        self.user.initiate_chat(
+            self.instructor,
+            message=f"Provide instructions to fix an answer based on these reasons why it is incorrect: {evaluation}",
+            summary_method="last_msg",
+        )
+        return self.user.last_message()["content"].strip()
+
+    def run(self, initial_prompt: str) -> dict[str, Any]:
+        prompt_to_evaluate = initial_prompt
+        worker_response = ""
+        evaluation = ""
+        for i in range(self.max_interactions):
+            worker_response = self.worker.respond(prompt_to_evaluate)
+            evaluation = self.evaluate_once(worker_response)
+            if evaluation.lower().startswith("yes"):
+                break
+            instructions = self.get_instructions(evaluation)
+            prompt_to_evaluate = (
+                f"The original prompt was: {initial_prompt}\n"
+                f"The response to that prompt was: {worker_response}\n"
+                f"It has been evaluated as incorrect.\n"
+                f"Make only these corrections, do not alter content validity: {instructions}"
+            )
+        return {
+            "final_response": worker_response,
+            "evaluation": evaluation,
+            "iterations": i + 1,
+        }
+
+    def respond(self, prompt: str) -> Any:
+        return self.run(prompt)
+

--- a/agentic-project-assistant/autogen_based/config.py
+++ b/agentic-project-assistant/autogen_based/config.py
@@ -1,0 +1,14 @@
+import os
+from dotenv import load_dotenv
+
+
+def load_openai_api_key() -> str:
+    """Return the OpenAI API key from environment variables or a .env file."""
+    load_dotenv()
+    return os.getenv("OPENAI_API_KEY")
+
+
+def load_openai_base_url() -> str:
+    """Return the OpenAI base URL, defaulting to Vocareum's endpoint."""
+    load_dotenv()
+    return os.getenv("OPENAI_BASE_URL", "https://openai.vocareum.com/v1")

--- a/agentic-project-assistant/autogen_based/main.py
+++ b/agentic-project-assistant/autogen_based/main.py
@@ -1,0 +1,190 @@
+"""Workflow using AutoGen-based agents."""
+
+from __future__ import annotations
+
+import os
+
+from config import load_openai_api_key, load_openai_base_url
+from utils.logging_config import logger
+
+from agents import (
+    ActionPlanningAgent,
+    KnowledgeAgent,
+    EvaluationAgent,
+)
+from routing_agent import RoutingAgent, Route
+from openai_service import OpenAIService
+
+
+def build_llm_config(api_key: str, base_url: str) -> dict:
+    return {
+        "config_list": [
+            {"model": "gpt-3.5-turbo", "api_key": api_key, "base_url": base_url}
+        ],
+        "cache_seed": 42,
+    }
+
+
+def main() -> None:
+    openai_api_key = load_openai_api_key()
+    openai_base_url = load_openai_base_url()
+    llm_config = build_llm_config(openai_api_key, openai_base_url)
+
+    service = OpenAIService(api_key=openai_api_key, base_url=openai_base_url)
+
+    product_spec_path = os.path.join(
+        os.path.dirname(__file__), "..", "no_framework", "Product-Spec-Email-Router.txt"
+    )
+    if not os.path.exists(product_spec_path):
+        raise FileNotFoundError(f"Product spec file not found at {product_spec_path}")
+
+    with open(product_spec_path, "r", encoding="utf-8") as file:
+        product_spec = file.read()
+
+    knowledge_action_planning = (
+        "Stories are defined from a product spec by identifying a persona, an action, and a desired outcome for each story. "
+        "Each story represents a specific functionality of the product described in the specification. \n"
+        "Features are defined by grouping related user stories. \n"
+        "Tasks are defined for each story and represent the engineering work required to develop the product. \n"
+        "A development Plan for a product contains all these components"
+    )
+    action_planning_agent = ActionPlanningAgent(llm_config=llm_config, knowledge=knowledge_action_planning)
+
+    persona_product_manager = "You are a Product Manager, you are responsible for defining the user stories for a product."
+    knowledge_product_manager = (
+        "Stories are defined by writing sentences with a persona, an action, and a desired outcome. "
+        "The sentences always start with: As a "
+        "Write several stories for the product spec below, where the personas are the different users of the product. "
+        f"Here is the product spec: {product_spec}"
+    )
+    product_manager_knowledge_agent = KnowledgeAgent(
+        llm_config=llm_config,
+        persona=persona_product_manager,
+        knowledge=knowledge_product_manager,
+    )
+    persona_product_manager_eval = "You are an evaluation agent that checks the answers of other worker agents."
+    evaluation_criteria_product_manager = (
+        "The answer should be user stories that follow this structure: "
+        "As a [type of user], I want [an action or feature] so that [benefit/value]. "
+        "Each user story should be clear, concise, and focused on a specific user need. "
+        "The user stories should be relevant to the product spec provided."
+    )
+    product_manager_evaluation_agent = EvaluationAgent(
+        llm_config=llm_config,
+        persona=persona_product_manager_eval,
+        evaluation_criteria=evaluation_criteria_product_manager,
+        worker=product_manager_knowledge_agent,
+    )
+
+    persona_program_manager = "You are a Program Manager, you are responsible for defining the features for a product."
+    knowledge_program_manager = "Features of a product are defined by organizing similar user stories into cohesive groups."
+    program_manager_knowledge_agent = KnowledgeAgent(
+        llm_config=llm_config,
+        persona=persona_program_manager,
+        knowledge=knowledge_program_manager,
+    )
+    persona_program_manager_eval = "You are an evaluation agent that checks the answers of other worker agents."
+    program_manager_evaluation_agent = EvaluationAgent(
+        llm_config=llm_config,
+        persona=persona_program_manager_eval,
+        evaluation_criteria=(
+            "The answer should be product features that follow the following structure: "
+            "Feature Name: A clear, concise title that identifies the capability\n"
+            "Description: A brief explanation of what the feature does and its purpose\n"
+            "Key Functionality: The specific capabilities or actions the feature provides\n"
+            "User Benefit: How this feature creates value for the user"
+        ),
+        worker=program_manager_knowledge_agent,
+    )
+
+    persona_dev_engineer = "You are a Development Engineer, you are responsible for defining the development tasks for a product."
+    knowledge_dev_engineer = "Development tasks are defined by identifying what needs to be built to implement each user story."
+    development_engineer_knowledge_agent = KnowledgeAgent(
+        llm_config=llm_config,
+        persona=persona_dev_engineer,
+        knowledge=knowledge_dev_engineer,
+    )
+    persona_dev_engineer_eval = "You are an evaluation agent that checks the answers of other worker agents."
+    development_engineer_evaluation_agent = EvaluationAgent(
+        llm_config=llm_config,
+        persona=persona_dev_engineer_eval,
+        evaluation_criteria=(
+            "The answer should be tasks following this exact structure: "
+            "Task ID: A unique identifier for tracking purposes\n"
+            "Task Title: Brief description of the specific development work\n"
+            "Related User Story: Reference to the parent user story\n"
+            "Description: Detailed explanation of the technical work required\n"
+            "Acceptance Criteria: Specific requirements that must be met for completion\n"
+            "Estimated Effort: Time or complexity estimation\n"
+            "Dependencies: Any tasks that must be completed first"
+        ),
+        worker=development_engineer_knowledge_agent,
+    )
+
+    def product_manager_support_function(query: str):
+        response = product_manager_knowledge_agent.respond(query)
+        return product_manager_evaluation_agent.run(response)
+
+    def program_manager_support_function(query: str):
+        response = program_manager_knowledge_agent.respond(query)
+        return program_manager_evaluation_agent.run(response)
+
+    def development_engineer_support_function(query: str):
+        response = development_engineer_knowledge_agent.respond(query)
+        return development_engineer_evaluation_agent.run(response)
+
+    routes = [
+        Route(
+            name="Product Manager",
+            description="Responsible for defining product personas and user stories only.",
+            func=product_manager_support_function,
+        ),
+        Route(
+            name="Program Manager",
+            description="A Program Manager, who is responsible for defining the features for a product.",
+            func=program_manager_support_function,
+        ),
+        Route(
+            name="Development Engineer",
+            description="A Development Engineer, who is responsible for defining the development tasks for a product.",
+            func=development_engineer_support_function,
+        ),
+    ]
+
+    routing_agent = RoutingAgent(openai_service=service, agents=routes)
+
+    logger.info("\n*** Workflow execution started ***\n")
+    workflow_prompt = "What would the development tasks for this product be?"
+    logger.info("Task to complete in this workflow, workflow prompt = %s", workflow_prompt)
+
+    logger.info("\nDefining workflow steps from the workflow prompt")
+    extracted_steps = action_planning_agent.extract_steps_from_prompt(workflow_prompt)
+    completed_steps: list = []
+    context_prompt = ""
+
+    logger.info("Extracted steps from the workflow prompt: %s\n", extracted_steps)
+    logger.info("Executing each step in the workflow...")
+
+    for i, step in enumerate(extracted_steps):
+        full_prompt = (context_prompt + f"\n{step}").strip()
+        logger.info("Executing step %d: %s", i + 1, step)
+        result = routing_agent.route(full_prompt)
+        completed_steps.append(result)
+        if isinstance(result, dict) and "final_response" in result:
+            context_prompt += "\n" + result["final_response"]
+        else:
+            context_prompt += "\n" + str(result)
+        logger.info("Result of step '%s': %s", step, result)
+
+    logger.info("Workflow completed successfully.")
+    logger.info("\n*** Workflow Results ***")
+
+    for i, step in enumerate(completed_steps, start=1):
+        logger.info("Step %d: %s", i, step)
+
+    logger.info("Final output of the workflow: %s", completed_steps[-1])
+    logger.info("\n*** Workflow execution finished ***\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic-project-assistant/autogen_based/openai_service.py
+++ b/agentic-project-assistant/autogen_based/openai_service.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from openai import OpenAI
+
+
+class OpenAIService:
+    """Simple wrapper around the OpenAI client used by the agents."""
+
+    def __init__(self, api_key: str, base_url: str = "https://openai.vocareum.com/v1") -> None:
+        """Create a client for communicating with the OpenAI API."""
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def chat(self, **kwargs: Any) -> Any:
+        """Call the chat completion endpoint and return the API response."""
+        return self.client.chat.completions.create(**kwargs)
+
+    def embed(self, **kwargs: Any) -> Any:
+        """Call the embeddings endpoint and return the API response."""
+        return self.client.embeddings.create(**kwargs)

--- a/agentic-project-assistant/autogen_based/routing_agent.py
+++ b/agentic-project-assistant/autogen_based/routing_agent.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+import numpy as np
+
+from utils.logging_config import logger
+
+from .base import BasicAgent, MODEL, Route
+from .openai_service import OpenAIService
+
+
+class RoutingAgent(BasicAgent):
+    """Select the best agent for a prompt based on description embeddings."""
+
+    def __init__(self, openai_service: OpenAIService, agents: List[Route]) -> None:
+        super().__init__(openai_service)
+        self.agents: List[Route] = []
+        for agent in agents:
+            if isinstance(agent, dict):
+                route = Route(
+                    name=agent["name"],
+                    description=agent["description"],
+                    func=agent["func"],
+                )
+            else:
+                route = agent
+            route.embedding = self.get_embedding(route.description)
+            self.agents.append(route)
+
+    def get_embedding(self, text: str) -> List[float]:
+        response = self.openai_service.embed(
+            model="text-embedding-3-large", input=text, encoding_format="float"
+        )
+        return response.data[0].embedding
+
+    def route(self, user_input: str) -> Any:
+        input_emb = self.get_embedding(user_input)
+        best_agent: Route | None = None
+        best_score = -1.0
+
+        for agent in self.agents:
+            agent_emb = np.array(agent.embedding)
+            if agent_emb.size == 0:
+                logger.warning("Warning: Agent '%s' has no embedding. Skipping.", agent.name)
+                continue
+
+            similarity = np.dot(input_emb, agent_emb) / (
+                np.linalg.norm(input_emb) * np.linalg.norm(agent_emb)
+            )
+            logger.debug(similarity)
+
+            if similarity > best_score:
+                best_score = similarity
+                best_agent = agent
+
+        if best_agent is None:
+            return "Sorry, no suitable agent could be selected."
+
+        logger.info("[Router] Best agent: %s (score=%.3f)", best_agent.name, best_score)
+        return best_agent.func(user_input)
+
+    # For interface compliance
+    def respond(self, prompt: str):
+        return self.route(prompt)

--- a/agentic-project-assistant/autogen_based/utils/logging_config.py
+++ b/agentic-project-assistant/autogen_based/utils/logging_config.py
@@ -1,0 +1,8 @@
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+logger = logging.getLogger("agentic_workflow")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ langchain==0.2.1
 tiktoken==0.5.2
 langchain_community
 tiktoken
+pyautogen


### PR DESCRIPTION
## Summary
- create an `autogen_based` implementation
- migrate `ActionPlanningAgent`, `KnowledgeAgent`, `EvaluationAgent` to use AutoGen
- replicate workflow logic in `autogen_based/main.py`
- copy helper utilities and update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c2ca551483289ad627340c897fa7